### PR TITLE
Changes to avoid issue while assembling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 usb/**
 **~
 website/css/main.css
+sbt/**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 Forked from https://github.com/databricks/spark-training/
+
 Training documentation at https://databricks-training.s3.amazonaws.com/movie-recommendation-with-mllib.html
 
 # Requisites
@@ -28,16 +29,9 @@ Execute your code
 ```
 make build run
 ```
+# More machine learning documentation and frameworks
 
-# Spark Camp training materials.
 
-This project holds the resources used for Spark Camp and other related training events. 
-The contents are as follows:
+https://github.com/josephmisiti/awesome-machine-learning
 
- * website - the jekyll-based website material hosted for training events
- * data - datasets used in the labs
- * sbt - a custom-configured version of sbt set-up to use a local cache when using a USB
- * simple-app - a toy project to test sbt builds
- * streaming - a streaming application used for labs
- * machine-learning - an ML application used for labs
- * build_usb.py - a build script for making the training usb
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+Forked from https://github.com/databricks/spark-training/
+Training documentation at https://databricks-training.s3.amazonaws.com/movie-recommendation-with-mllib.html
+
+# Requisites
+* Spark installed 
+* $SPARK_HOME defined
+```
+export SPARK_HOME=~/software/spark-1.1.1
+```
+
+# Getting started
+```
+git clone git@github.com:jonasanso/spark-training.git
+cd spark-training/machine-learning/scala
+make build
+``` 
+
+# Movie recommendation exercise
+Rate some movies with your own preferences
+```
+make rate
+```
+
+Follow trining steps
+https://databricks-training.s3.amazonaws.com/movie-recommendation-with-mllib.html
+
+Execute your code
+```
+make build run
+```
+
 # Spark Camp training materials.
 
 This project holds the resources used for Spark Camp and other related training events. 
@@ -10,5 +41,3 @@ The contents are as follows:
  * streaming - a streaming application used for labs
  * machine-learning - an ML application used for labs
  * build_usb.py - a build script for making the training usb
-
-

--- a/machine-learning/scala/Makefile
+++ b/machine-learning/scala/Makefile
@@ -1,0 +1,6 @@
+rate:
+	python ../bin/rateMovies
+build: 
+	../../sbt/sbt assembly  
+run:
+	${SPARK_HOME}/bin/spark-submit --class MovieLensALS target/scala-2.10/movielens-als-assembly-0.1.jar ../../data/movielens/medium/ ../personalRatings.txt

--- a/machine-learning/scala/build.sbt
+++ b/machine-learning/scala/build.sbt
@@ -2,10 +2,23 @@ import AssemblyKeys._
 
 assemblySettings
 
+mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
+{
+  case PathList(ps @ _*) if ps.last endsWith "ECLIPSEF.RSA" => MergeStrategy.first
+  case PathList(ps @ _*) if ps.last endsWith "plugin.properties" => MergeStrategy.concat
+  case PathList(ps @ _*) if ps.last endsWith "mailcap" => MergeStrategy.first
+  case x => old(x)
+}
+}
+
 name := "movielens-als"
 
 version := "0.1"
 
 scalaVersion := "2.10.4"
 
-libraryDependencies += "org.apache.spark" % "spark-mllib_2.10" % "1.1.0"
+libraryDependencies += ("org.apache.spark" % "spark-mllib_2.10" % "1.1.0").
+  exclude("com.esotericsoftware.minlog", "minlog").
+  exclude("commons-collections", "commons-collections").
+  exclude("commons-logging", "commons-logging").
+  exclude("commons-beanutils", "commons-beanutils-core")


### PR DESCRIPTION
After cloning the project, executing sbt assembly gave me the following error:

[error](*:assembly) deduplicate: different file contents found in the following:
[error] /home/jonas/hacks/spark-training/sbt/ivy/cache/org.eclipse.jetty.orbit/javax.transaction/orbits/javax.transaction-1.1.1.v201105210645.jar:META-INF/ECLIPSEF.RSA
[error] /home/jonas/hacks/spark-training/sbt/ivy/cache/org.eclipse.jetty.orbit/javax.servlet/orbits/javax.servlet-3.0.0.v201112011016.jar:META-INF/ECLIPSEF.RSA
[error] /home/jonas/hacks/spark-training/sbt/ivy/cache/org.eclipse.jetty.orbit/javax.mail.glassfish/orbits/javax.mail.glassfish-1.4.1.v201005082020.jar:META-INF/ECLIPSEF.RSA
[error] /home/jonas/hacks/spark-training/sbt/ivy/cache/org.eclipse.jetty.orbit/javax.activation/orbits/javax.activation-1.1.0.v201105071233.jar:META-INF/ECLIPSEF.RSA

I simply did my best trying to workaround the issue.
Probably there is a cleaner solution but at lease with this changes I could assemble the job.

Thanks for the training exercise and merge this pull if appropriate. 
