### PR TITLE
Fixing build.sbt based on http://bit.ly/1sUSzvC

### DIFF
--- a/machine-learning/scala/build.sbt
+++ b/machine-learning/scala/build.sbt
@@ -8,4 +8,4 @@ version := "0.1"
 
 scalaVersion := "2.10.4"
 
-libraryDependencies += "org.apache.spark" % "spark-mllib_2.10" % "1.1.0"
+libraryDependencies += "org.apache.spark" % "spark-mllib_2.10" % "1.1.0" % "provided"


### PR DESCRIPTION
This fixes building of machine-learning on OSX.  `sbt build` would otherwise return the "java.lang.RuntimeException: deduplicate: different file contents found in the following"